### PR TITLE
US. Viewer layout changes & Error handling

### DIFF
--- a/extensions/default/src/DicomWebDataSource/index.js
+++ b/extensions/default/src/DicomWebDataSource/index.js
@@ -278,7 +278,7 @@ function createDicomWebApi(webConfig, UserAuthenticationService) {
           sortCriteria,
           sortFunction,
           madeInClient = false,
-          withCredentials = !!webConfig.withCredentials
+          withCredentials = !!webConfig.withCredentials,
         } = {}) => {
           const headers = UserAuthenticationService.getAuthorizationHeader();
           if (headers) {
@@ -528,7 +528,7 @@ function createDicomWebApi(webConfig, UserAuthenticationService) {
           storeInstances(instances);
         })
       );
-      await Promise.all(seriesDeliveredPromises);
+      await Promise.allSettled(seriesDeliveredPromises);
       setSuccessFlag();
     },
     deleteStudyMetadataPromise,

--- a/platform/viewer/src/components/EmptyViewport.tsx
+++ b/platform/viewer/src/components/EmptyViewport.tsx
@@ -9,13 +9,14 @@ function EmptyViewport(props) {
         props.className
       )}
     >
-      <div className="failed items-center">
-        <rapid-icon-button
-          icon="refresh-48"
-          className="reload-button large"
-        ></rapid-icon-button>
-
-        <span className="message">Restart Download</span>
+      <div className="failed items-center flex flex-col">
+        <div className="box-48-horizontal">
+          <rapid-icon-button
+            icon="refresh-48"
+            class="medium"
+          ></rapid-icon-button>
+        </div>
+        <span className="message">Reload</span>
         <span className="sub-message">Images failed to download</span>
       </div>
     </div>

--- a/platform/viewer/src/components/EmptyViewport.tsx
+++ b/platform/viewer/src/components/EmptyViewport.tsx
@@ -1,7 +1,25 @@
 import React from 'react';
+import classNames from 'classnames';
 
-function EmptyViewport() {
-  return <div></div>;
+function EmptyViewport(props) {
+  return (
+    <div
+      className={classNames(
+        'absolute z-50 top-0 left-0 flex flex-col items-center justify-center space-y-5',
+        props.className
+      )}
+    >
+      <div className="failed items-center">
+        <rapid-icon-button
+          icon="refresh-48"
+          className="reload-button large"
+        ></rapid-icon-button>
+
+        <span className="message">Restart Download</span>
+        <span className="sub-message">Images failed to download</span>
+      </div>
+    </div>
+  );
 }
 
 export default EmptyViewport;

--- a/platform/viewer/src/components/ViewportGrid.tsx
+++ b/platform/viewer/src/components/ViewportGrid.tsx
@@ -399,6 +399,7 @@ function ViewerViewportGrid(props) {
               viewportOptions={viewportOptions}
               displaySetOptions={displaySetOptions}
               needsRerendering={displaySetsNeedsRerendering}
+              className="h-full w-full bg-black"
             />
           </div>
         </ViewportPane>

--- a/platform/viewer/src/routes/Mode/Mode.tsx
+++ b/platform/viewer/src/routes/Mode/Mode.tsx
@@ -33,6 +33,7 @@ function defaultRouteInit(
   const {
     DisplaySetService,
     HangingProtocolService,
+    ErrorHandlingService,
   } = servicesManager.services;
 
   const unsubscriptions = [];
@@ -121,7 +122,17 @@ function defaultRouteInit(
     }
   );
 
-  Promise.allSettled(allRetrieves).then(() => {
+  Promise.allSettled(allRetrieves).then(promiseStatus => {
+    promiseStatus.forEach(prStatus => {
+      // iterate over every promise and check status, if any promise is have error encounter then status will be rejected
+      if (prStatus.status === 'rejected') {
+        if (ErrorHandlingService) {
+          ErrorHandlingService.broadcastStudyLoadError();
+        }
+        return;
+      }
+    });
+
     const displaySets = DisplaySetService.getActiveDisplaySets();
 
     if (!displaySets || !displaySets.length) {

--- a/platform/viewer/src/routes/Mode/Mode.tsx
+++ b/platform/viewer/src/routes/Mode/Mode.tsx
@@ -300,8 +300,12 @@ export default function ModeRoute({
   }, [location]);
 
   useEffect(() => {
-    const { ExternalInterfaceService } = servicesManager.services;
+    const {
+      ExternalInterfaceService,
+      PerformanceEventTrackingService,
+    } = servicesManager.services;
     ExternalInterfaceService.sendViewerReady();
+    PerformanceEventTrackingService.startAxialFIDTime();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Error handling

1. when study not found show error message
2. When series not found continue study load - use promise.settledAll()
3. Empty viewport - show message when hanging protocol not found